### PR TITLE
Fix saving of tags

### DIFF
--- a/html/Elements/EditCustomFieldTags
+++ b/html/Elements/EditCustomFieldTags
@@ -1,17 +1,17 @@
-<textarea name="<% $name %>-Values" id="<% $name %>-Values" class="CF-<%$CustomField->id%>-Edit"><% $Default || '' %></textarea>
+<textarea name="<% $name %>" id="<% $name %>" class="CF-<%$CustomField->id%>-Edit"><% $Default || '' %></textarea>
 <script type="text/javascript">
-var id = <% "$name-Values" |n,j%>;
+var id = <% "$name" |n,j%>;
 id = id.replace(/:/g,'\\:');
 jQuery('#'+id).tagit({
   autocomplete: {
-    source: <%RT->Config->Get('WebPath') |n,j%>+"/Helpers/Autocomplete/CustomFieldValues?"+<% $Context |n,j %>+<% "$name-Values" |n,u,j%>,
+    source: <%RT->Config->Get('WebPath') |n,j%>+"/Helpers/Autocomplete/CustomFieldValues?"+<% $Context |n,j %>+<% "$name" |n,u,j%>,
   },
   tagLimit: <% $CustomField->MaxValues+0 || "null" |n %>,
   singleFieldDelimiter: "\n"
 });
 </script>
 <%INIT>
-my $name = $NamePrefix . $CustomField->Id;
+my $name = $Name || $NamePrefix . $CustomField->Id . "-Values";
 if ( $Default && !$Multiple ) {
     $Default =~ s/\s*\r*\n\s*/ /g;
 }
@@ -29,6 +29,7 @@ if ($CustomField->ContextObject) {
 </%INIT>
 <%ARGS>
 $CustomField => undef
+$Name        => undef
 $NamePrefix  => undef
 $Default     => undef
 $Values      => undef


### PR DESCRIPTION
Use $Name to determine the name of the field to set, if that variable is
defined. Otherwise construct it from the $NamePrefix value as previously.

This makes the extension work with our installation of RT 4.4.0