### PR TITLE
Add bulk edit of tags

### DIFF
--- a/html/Elements/BulkCustomFields
+++ b/html/Elements/BulkCustomFields
@@ -1,0 +1,112 @@
+%# BEGIN BPS TAGGED BLOCK {{{
+%#
+%# COPYRIGHT:
+%#
+%# This software is Copyright (c) 1996-2016 Best Practical Solutions, LLC
+%#                                          <sales@bestpractical.com>
+%#
+%# (Except where explicitly superseded by other copyright notices)
+%#
+%#
+%# LICENSE:
+%#
+%# This work is made available to you under the terms of Version 2 of
+%# the GNU General Public License. A copy of that license should have
+%# been provided with this software, but in any event can be snarfed
+%# from www.gnu.org.
+%#
+%# This work is distributed in the hope that it will be useful, but
+%# WITHOUT ANY WARRANTY; without even the implied warranty of
+%# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+%# General Public License for more details.
+%#
+%# You should have received a copy of the GNU General Public License
+%# along with this program; if not, write to the Free Software
+%# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+%# 02110-1301 or visit their web page on the internet at
+%# http://www.gnu.org/licenses/old-licenses/gpl-2.0.html.
+%#
+%#
+%# CONTRIBUTION SUBMISSION POLICY:
+%#
+%# (The following paragraph is not intended to limit the rights granted
+%# to you to modify and distribute this software under the terms of
+%# the GNU General Public License and is only of importance to you if
+%# you choose to contribute your changes and enhancements to the
+%# community by submitting them to Best Practical Solutions, LLC.)
+%#
+%# By intentionally submitting any modifications, corrections or
+%# derivatives to this work, or any other work intended for use with
+%# Request Tracker, to Best Practical Solutions, LLC, you confirm that
+%# you are the copyright holder for those contributions and you grant
+%# Best Practical Solutions,  LLC a nonexclusive, worldwide, irrevocable,
+%# royalty-free, perpetual, license to use, copy, create derivative
+%# works based on those contributions, and sublicense and distribute
+%# those contributions and any derivatives thereof.
+%#
+%# END BPS TAGGED BLOCK }}}
+<table class="bulk-edit-custom-fields">
+
+<tr>
+<th><&|/l&>Name</&></th>
+<th><&|/l&>Add values</&></th>
+<th><&|/l&>Delete values</&></th>
+</tr>
+% my $i = 0;
+% while (my $cf = $CustomFields->Next) {
+<tr class="<% ++$i%2 ? 'oddline': 'evenline' %>">
+<td class="label"><% $cf->Name %><br />
+<em>(<% $cf->EntryHint // '' %>)</em></td>
+% my $rows = 5;
+% my $cf_id = $cf->id;
+% my @add = (NamePrefix => 'Bulk-Add-CustomField-', CustomField => $cf, Rows => $rows,
+%   Multiple => ($cf->MaxValues ==1 ? 0 : 1) , Cols => 25,
+%   Default => $ARGS{"Bulk-Add-CustomField-$cf_id-Values"} || $ARGS{"Bulk-Add-CustomField-$cf_id-Value"}, );
+% my @del = (NamePrefix => 'Bulk-Delete-CustomField-', CustomField => $cf,
+%   Rows => $rows, Multiple => 1, Cols => 25,
+%   Default => $ARGS{"Bulk-Delete-CustomField-$cf_id-Values"} || $ARGS{"Bulk-Delete-CustomField-$cf_id-Value"}, );
+% if ($cf->Type eq 'Select') {
+<td><& /Elements/EditCustomFieldSelect, @add &></td>
+<td><& /Elements/EditCustomFieldSelect, @del &><br />
+% } elsif ($cf->Type eq 'Combobox') {
+<td><& /Elements/EditCustomFieldCombobox, @add &></td>
+<td><& /Elements/EditCustomFieldCombobox, @del &><br />
+% } elsif ($cf->Type eq 'Freeform') {
+<td><& /Elements/EditCustomFieldFreeform, @add &></td>
+<td><& /Elements/EditCustomFieldFreeform, @del &><br />
+% } elsif ($cf->Type eq 'Text') {
+<td><& /Elements/EditCustomFieldText, @add &></td>
+<td>
+% } elsif ($cf->Type eq 'Wikitext') {
+<td><& /Elements/EditCustomFieldWikitext, @add &></td>
+<td>
+% } elsif ($cf->Type eq 'Date') {
+<td><& /Elements/EditCustomFieldDate, @add &></td>
+<td><& /Elements/EditCustomFieldDate, @del &><br />
+% } elsif ($cf->Type eq 'DateTime') {
+% # Pass datemanip format to prevent another tz date conversion
+<td><& /Elements/EditCustomFieldDateTime, @add, Default => undef, Format => 'datemanip' &></td>
+<td><& /Elements/EditCustomFieldDateTime, @del, Default => undef, Format => 'datemanip' &><br />
+% } elsif ($cf->Type eq 'Autocomplete') {
+<td><& /Elements/EditCustomFieldAutocomplete, @add &></td>
+<td><& /Elements/EditCustomFieldAutocomplete, @del &><br />
+% } elsif ($cf->Type eq 'Tags') {
+<td><& /Elements/EditCustomFieldTags, @add &></td>
+<td><& /Elements/EditCustomFieldTags, @del &><br />
+% } else {
+    <td colspan="2"><em><&|/l&>(Unsupported custom field type)</&></em></td>
+%   $RT::Logger->crit("Unknown CustomField type: " . $cf->Type);
+%   next
+% }
+  <label><input type="checkbox" name="Bulk-Delete-CustomField-<% $cf_id %>-AllValues" value="1">
+    <em><&|/l&>(Check to delete all values)</&></em></label>
+</td>
+</tr>
+% }
+</table>
+<%ARGS>
+$CustomFields
+</%ARGS>
+<%INIT>
+return unless $CustomFields->Count;
+</%INIT>


### PR DESCRIPTION
I just added a copy of the BulkCustomFields element with the necessary logic (lines 93-95)so that the `Tags` custom field type is recognized in the Bulk Edit page.

**Cons**: the extension would need to be updated if this Element changes in future versions.

Maybe `rt_too_new` in Makefile.PL should be set to 4.4.1?