### PR TITLE
Needs Class set for search results

### DIFF
--- a/html/Elements/ShowCustomFieldTags
+++ b/html/Elements/ShowCustomFieldTags
@@ -14,6 +14,7 @@ if ( RT::Handle::cmp_version($RT::VERSION, "4.4.0") < 0 ){
 
 my $cf = $Object->CustomFieldObj;
 my $cf_id = $cf->id;
+my $class = $cf->CollectionClassFromLookupType($cf->ObjectTypeFromLookupType);
 my $query_value = $Object->LargeContent || $Object->Content;
 $query_value =~ s/(['\\])/\\$1/g;
 my $query = "CF.{$cf_id} = '$query_value' AND $status";
@@ -21,7 +22,7 @@ RT::Interface::Web::EscapeURI(\$query);
 
 </%init>
 % if (not $cf->LinkValueTo) {
-<a href="<% RT->Config->Get('WebPath') %>/Search/Results.html?Query=<% $query %>">
+<a href="<% RT->Config->Get('WebPath') %>/Search/Results.html?Class=<% $class %>&Query=<% $query %>">
 % }
 <%$content|n%>
 % if (not $cf->LinkValueTo) {


### PR DESCRIPTION
Since Tags CustomFields can be added to other object types (e.g. Assets), the search when clicking on a displayed tag needs to return results for the appropriate object type. This should do that automatically.